### PR TITLE
Change tabs in dbt_project.yml to 2 spaces instead of 4

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -20,8 +20,8 @@ snapshot-paths: ["snapshots"]
 
 target-path: "target"  # directory which will store compiled SQL files
 clean-targets:         # directories to be removed by `dbt clean`
-    - "target"
-    - "dbt_modules"
+  - "target"
+  - "dbt_modules"
 
 
 # Configuring models
@@ -32,6 +32,6 @@ clean-targets:         # directories to be removed by `dbt clean`
 # using the `{{ config(...) }}` macro.
 models:
   my_new_project:
-      # Applies to all files under models/example/
-      example:
-          materialized: view
+    # Applies to all files under models/example/
+    example:
+      materialized: view


### PR DESCRIPTION
# Details
Changes the `dbt_project.yml` file tab length to align with the tab length of 2 spaces specified in the [YAML style guide section of the internal dbt coding convention docs](https://github.com/fishtown-analytics/corp/blob/master/dbt_coding_conventions.md#yaml-style-guide) AND the [dbt_project.yml page on docs](https://docs.getdbt.com/reference/dbt_project.yml/). Unifying the tab length will make it easier for users to copy and paste from the docs into their first projects, an issue that we see a lot of users run into during dbt Learn sessions.

# Testing
Copy and pasted this into the `dbt_project.yml` in a new project in dbt Cloud. Ran `dbt run` without any issues. See screenshots below.

![Screen Shot 2021-01-27 at 3 07 01 PM](https://user-images.githubusercontent.com/1040267/106066389-99c16b80-60b1-11eb-947a-8c35947d6017.png)

![Screen Shot 2021-01-27 at 3 07 15 PM](https://user-images.githubusercontent.com/1040267/106066384-96c67b00-60b1-11eb-8d1c-2b5aac2ab1ef.png)