### PR TITLE
update from dbt_modules to dbt_packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 target/
-dbt_modules/
+dbt_packages/
 logs/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 target/
 dbt_packages/
 logs/
+
+# legacy -- renamed to dbt_packages in v1
+dbt_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# you shouldn't commit these into source control
+# these are the default directory names, adjust/add to fit your needs
 target/
 dbt_packages/
 logs/


### PR DESCRIPTION
saw this in a community convo, experienced myself

it seems like `dbt deps` by default/the way the project YAML is setup uses `dbt_packages`, but this has `dbt_modules` in the `.gitignore` leading to errant commits of package code
