### PR TITLE
Fix community link typo in README.me

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ Try running the following commands:
 ### Resources:
 - Learn more about dbt [in the docs](https://docs.getdbt.com/docs/introduction)
 - Check out [Discourse](https://discourse.getdbt.com/) for commonly asked questions and answers
-- Join the [dbt community](http://community.getdbt.com/) to learn from other analytics engineers
+- Join the [dbt community](https://getdbt.com/community) to learn from other analytics engineers
 - Find [dbt events](https://events.getdbt.com) near you
 - Check out [the blog](https://blog.getdbt.com/) for the latest news on dbt's development and best practices

--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ Try running the following commands:
 ### Resources:
 - Learn more about dbt [in the docs](https://docs.getdbt.com/docs/introduction)
 - Check out [Discourse](https://discourse.getdbt.com/) for commonly asked questions and answers
-- Join the [dbt community](http://community.getbdt.com/) to learn from other analytics engineers
+- Join the [dbt community](http://community.getdbt.com/) to learn from other analytics engineers
 - Find [dbt events](https://events.getdbt.com) near you
 - Check out [the blog](https://blog.getdbt.com/) for the latest news on dbt's development and best practices


### PR DESCRIPTION
The dbt community link was incorrectly listed as http://community.getbdt.com. Changed it to http://community.getdbt.com/